### PR TITLE
Adds CODEOWNERS back along with .syncignore

### DIFF
--- a/.github/.syncignore
+++ b/.github/.syncignore
@@ -1,0 +1,1 @@
+CODEOWNERS

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @paketo-community/ruby-maintainers


### PR DESCRIPTION
It looks like the CODEOWNERS file was auto-removed in a sync that happened recently. I've included a .syncignore here so that it will remain in place.