### PR TITLE
Attempt using the --password-stdin flag

### DIFF
--- a/.github/workflows/push-buildpackage.yml
+++ b/.github/workflows/push-buildpackage.yml
@@ -14,6 +14,6 @@ jobs:
       uses: paketo-buildpacks/github-config/actions/buildpackage/download@gcr-push
     - name: Push
       run: |
-        docker login --username _json_key --password "${{ secrets.GCR_PUSH_BOT_JSON_KEY }}" gcr.io
+        echo "${{ secrets.GCR_PUSH_BOT_JSON_KEY }}" | docker login gcr.io --username _json_key --password-stdin
         docker import image "${GITHUB_WORKSPACE}/${{ steps.download.outputs.buildpackage }}" "gcr.io/${{ github.repository }}:${{ steps.download.outputs.tag }}"
         docker push "gcr.io/${{ github.repository }}:${{ steps.download.outputs.tag }}"


### PR DESCRIPTION
Sadly, it looks like actions is really fussy about what forms of arguments it will pass along to the `docker login` command. This is the form that they promote in their own `starter-workflows` repo: https://github.com/actions/starter-workflows/blob/87a8d83e309a179bf1d126a21cb7669c830b0e0e/ci/docker-publish.yml#L54